### PR TITLE
feat: add full name support for test case name

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -73,6 +73,8 @@ type TestSuite struct {
 	Namespace string `json:"namespace"`
 	// Suppress is used to suppress logs
 	Suppress []string `json:"suppress"`
+	// FullName makes use of the full test case folder path instead of the folder name.
+	FullName bool
 
 	Config *RestConfig `json:"config,omitempty"`
 }

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -56,6 +56,7 @@ func newTestCmd() *cobra.Command { //nolint:gocyclo
 	artifactsDir := ""
 	mockControllerFile := ""
 	timeout := 30
+	fullName := false
 	reportFormat := ""
 	reportName := "kuttl-report"
 	namespace := ""
@@ -177,6 +178,10 @@ For more detailed documentation, visit: https://kuttl.dev`,
 				options.ArtifactsDir = artifactsDir
 			}
 
+			if isSet(flags, "full-name") {
+				options.FullName = fullName
+			}
+
 			if isSet(flags, "namespace") {
 				if strings.TrimSpace(namespace) == "" {
 					return errors.New(`setting namespace explicitly to "" or empty string is not supported`)
@@ -257,6 +262,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 	testCmd.Flags().StringSliceVar(&suppress, "suppress-log", []string{}, "Suppress logging for these kinds of logs (events).")
 	// This cannot be a global flag because pkg/test/utils.RunTests calls flag.Parse which barfs on unknown top-level flags.
 	// Putting it here at least does not advertise it on a level where using it is impossible.
+	testCmd.Flags().BoolVar(&fullName, "full-name", false, "If set, uses the full test case folder path instead of folder name.")
 	test.SetFlags(testCmd.Flags())
 
 	return testCmd

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -378,18 +379,23 @@ func (h *Harness) RunTests() {
 				test.Client = h.Client
 				test.DiscoveryClient = h.DiscoveryClient
 
+				name := test.Name
+				if h.TestSuite.FullName {
+					name = path.Join(strings.Trim(strings.Trim(testDir, "."), "/"), name)
+				}
+
 				t.Run(test.Name, func(t *testing.T) {
 					// testing.T.Parallel may block, so run it before we read time for our
 					// elapsed time calculations.
 					t.Parallel()
 
-					test.Logger = testutils.NewTestLogger(t, test.Name)
+					test.Logger = testutils.NewTestLogger(t, name)
 
 					if err := test.LoadTestSteps(); err != nil {
 						t.Fatal(err)
 					}
 
-					tc := report.NewCase(test.Name)
+					tc := report.NewCase(name)
 					test.Run(t, tc)
 					suite.AddTestcase(tc)
 				})


### PR DESCRIPTION
This PR adds support for full folder path in the test name (instead of the shorter folder name).
This is useful when test cases are organised in deep folder hierarchy.
