### PR TITLE
[Enhancement] YAML validation of a TestStep file

### DIFF
--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -696,9 +696,6 @@ func hasTimeoutErr(err []error) bool {
 }
 
 func validateTestStep(ts *harness.TestStep, baseDir string) error {
-	if (len(ts.Assert) != 0 || len(ts.Error) != 0) && len(ts.Apply) == 0 {
-		return fmt.Errorf("the 'apply' field is required when 'assert' or 'error' fields are present")
-	}
 
 	// Check if referenced files in Apply exist
 	for _, apply := range ts.Apply {

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -696,7 +696,6 @@ func hasTimeoutErr(err []error) bool {
 }
 
 func validateTestStep(ts *harness.TestStep, baseDir string) error {
-
 	// Check if referenced files in Apply exist
 	for _, apply := range ts.Apply {
 		path := filepath.Join(baseDir, apply.File)

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"gopkg.in/yaml.v2"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -561,6 +563,10 @@ func (s *Step) LoadYAML(file string) error {
 	for _, apply := range s.Apply {
 		if apply.object.GetObjectKind().GroupVersionKind().Kind == "TestStep" {
 			if testStep, ok := apply.object.(*harness.TestStep); ok {
+				// Validate TestStep
+				if err := validateTestStep(testStep, s.Dir); err != nil {
+					return fmt.Errorf("failed to validate TestStep object from %s: %v", file, err)
+				}
 				if s.Step != nil {
 					return fmt.Errorf("more than 1 TestStep not allowed in step %q", s.Name)
 				}
@@ -687,4 +693,58 @@ func hasTimeoutErr(err []error) bool {
 		}
 	}
 	return false
+}
+
+func validateTestStep(ts *harness.TestStep, baseDir string) error {
+	if len(ts.Apply) == 0 {
+		return fmt.Errorf("the 'Apply' field is required and missing")
+	}
+
+	// Check if referenced files in Apply exist
+	for _, apply := range ts.Apply {
+		path := filepath.Join(baseDir, apply.File)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return fmt.Errorf("referenced file in Apply does not exist: %s", path)
+		}
+		if err := checkYAMLError(path); err != nil {
+			return err
+		}
+	}
+	// Check if referenced files in  Assert  exist
+	for _, assert := range ts.Assert {
+		path := filepath.Join(baseDir, assert)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return fmt.Errorf("referenced file in Assert does not exist: %s", path)
+		}
+		if err := checkYAMLError(path); err != nil {
+			return err
+		}
+	}
+	// Check if referenced files in  Error exist
+	for _, errorPath := range ts.Error {
+		path := filepath.Join(baseDir, errorPath)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return fmt.Errorf("referenced file in Error does not exist: %s", path)
+		}
+		if err := checkYAMLError(path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkYAMLError checks for YAML structural or indentation errors in the given file path.
+func checkYAMLError(path string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("error reading file %s: %v", path, err)
+	}
+
+	var data map[string]interface{}
+	if err := yaml.Unmarshal(content, &data); err != nil {
+		return fmt.Errorf("YAML indentation or structural error in file %s: %v", path, err)
+	}
+
+	return nil
 }

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -696,8 +696,11 @@ func hasTimeoutErr(err []error) bool {
 }
 
 func validateTestStep(ts *harness.TestStep, baseDir string) error {
-	if len(ts.Apply) == 0 {
-		return fmt.Errorf("the 'Apply' field is required and missing")
+	if len(ts.Apply) == 0 && len(ts.Commands) == 0 && len(ts.Delete) == 0 {
+		return fmt.Errorf("invalid test step configuration: at least one of 'apply', 'command', or 'delete' must be specified")
+	}
+	if (len(ts.Assert) != 0 || len(ts.Error) != 0) && len(ts.Apply) == 0 {
+		return fmt.Errorf("the 'apply' field is required when 'assert' or 'error' fields are present")
 	}
 
 	// Check if referenced files in Apply exist

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -742,7 +742,7 @@ func checkYAMLError(path string) error {
 	}
 
 	var data map[string]interface{}
-	if err := yaml.Unmarshal(content, &data); err != nil {
+	if err := yaml.UnmarshalStrict(content, &data); err != nil {
 		return fmt.Errorf("YAML indentation or structural error in file %s: %v", path, err)
 	}
 

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -696,9 +696,6 @@ func hasTimeoutErr(err []error) bool {
 }
 
 func validateTestStep(ts *harness.TestStep, baseDir string) error {
-	if len(ts.Apply) == 0 && len(ts.Commands) == 0 && len(ts.Delete) == 0 {
-		return fmt.Errorf("invalid test step configuration: at least one of 'apply', 'command', or 'delete' must be specified")
-	}
 	if (len(ts.Assert) != 0 || len(ts.Error) != 0) && len(ts.Apply) == 0 {
 		return fmt.Errorf("the 'apply' field is required when 'assert' or 'error' fields are present")
 	}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -740,15 +741,13 @@ func checkYAMLError(path string) error {
 		return fmt.Errorf("error reading file %s: %v", path, err)
 	}
 
-	manifests := strings.Split(string(content), "---")
-	for _, manifest := range manifests {
-		manifest = strings.TrimSpace(manifest)
-		if manifest == "" {
-			continue
-		}
-
+	decoder := yaml.NewDecoder(strings.NewReader(string(content)))
+	decoder.SetStrict(true)
+	for {
 		var data map[string]interface{}
-		if err := yaml.UnmarshalStrict([]byte(manifest), &data); err != nil {
+		if err := decoder.Decode(&data); err == io.EOF {
+			break
+		} else if err != nil {
 			return fmt.Errorf("YAML indentation or structural error in file %s: %v", path, err)
 		}
 

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -4,7 +4,9 @@ package test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -337,10 +339,15 @@ func TestApplyExpansion(t *testing.T) {
 	t.Cleanup(func() {
 		os.Unsetenv("TEST_FOO")
 	})
+	dirPath := filepath.Join(t.TempDir(), "step_integration_test_data/assert_expand")
+	err := os.MkdirAll(dirPath, 0755)
+	assert.NoError(t, err)
+	yamlFilePath := filepath.Join(dirPath, "00-step1.yaml")
+	err = ioutil.WriteFile(yamlFilePath, []byte, 0644)
+	assert.NoError(t, err)
 
-	step := Step{Dir: "step_integration_test_data/assert_expand/"}
-	path := "step_integration_test_data/assert_expand/00-step1.yaml"
-	err := step.LoadYAML(path)
+	step := Step{Dir: dirPath}
+	err = step.LoadYAML(yamlFilePath)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(step.Apply))
 }

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -343,7 +343,18 @@ func TestApplyExpansion(t *testing.T) {
 	err := os.MkdirAll(dirPath, 0755)
 	assert.NoError(t, err)
 	yamlFilePath := filepath.Join(dirPath, "00-step1.yaml")
-	err = ioutil.WriteFile(yamlFilePath, []byte{}, 0644)
+
+	data := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+    - image: alpine
+      name: test
+`
+	err = ioutil.WriteFile(yamlFilePath, []byte(data), 0644)
 	assert.NoError(t, err)
 
 	step := Step{Dir: dirPath}

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -343,7 +343,7 @@ func TestApplyExpansion(t *testing.T) {
 	err := os.MkdirAll(dirPath, 0755)
 	assert.NoError(t, err)
 	yamlFilePath := filepath.Join(dirPath, "00-step1.yaml")
-	err = ioutil.WriteFile(yamlFilePath, []byte, 0644)
+	err = ioutil.WriteFile(yamlFilePath, []byte{}, 0644)
 	assert.NoError(t, err)
 
 	step := Step{Dir: dirPath}

--- a/pkg/test/step_integration_test_data/kubeconfig_path_resolution/00-step1.yaml
+++ b/pkg/test/step_integration_test_data/kubeconfig_path_resolution/00-step1.yaml
@@ -1,4 +1,3 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 kubeconfig: ./kubeconfig-${SUBPATH}.yaml
-timeout: 30

--- a/pkg/test/step_integration_test_data/kubeconfig_path_resolution/00-step2.yaml
+++ b/pkg/test/step_integration_test_data/kubeconfig_path_resolution/00-step2.yaml
@@ -1,4 +1,3 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 kubeconfig: /absolute/kubeconfig-${SUBPATH}.yaml
-timeout: 30

--- a/pkg/test/step_integration_test_data/two_step/00-step1.yaml
+++ b/pkg/test/step_integration_test_data/two_step/00-step1.yaml
@@ -1,3 +1,2 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 30

--- a/pkg/test/step_integration_test_data/two_step/00-step2.yaml
+++ b/pkg/test/step_integration_test_data/two_step/00-step2.yaml
@@ -1,3 +1,2 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 30

--- a/pkg/test/step_integration_test_data/two_step/01-step1.yaml
+++ b/pkg/test/step_integration_test_data/two_step/01-step1.yaml
@@ -1,8 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 30
 
 ----
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 30

--- a/pkg/test/test_data/teststep-assert/00-create.yaml
+++ b/pkg/test/test_data/teststep-assert/00-create.yaml
@@ -1,24 +1,9 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: hello2
-spec:
-  containers:
-    - image: alpine
-      name: test
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: hello
-spec:
-  containers:
-    - image: alpine
-      name: test
----
 # using assert from TestStep from multiple folder locations
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
+apply:
+  - hello1-pod.yaml
+  - hello2/hello2-pod.yaml
 assert:
   - hello1-assert.yaml
   - hello2/hello2-assert.yaml

--- a/pkg/test/test_data/teststep-assert/hello1-pod.yaml
+++ b/pkg/test/test_data/teststep-assert/hello1-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+    - image: alpine
+      name: test

--- a/pkg/test/test_data/teststep-assert/hello2/hello2-pod.yaml
+++ b/pkg/test/test_data/teststep-assert/hello2/hello2-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello2
+spec:
+  containers:
+    - image: alpine
+      name: test

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -412,7 +412,7 @@ func ConvertUnstructured(in client.Object) (client.Object, error) {
 		return in, nil
 	}
 
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstruct, converted)
+	err = runtime.DefaultUnstructuredConverter.FromUnstructuredWithValidation(unstruct, converted, true)
 	if err != nil {
 		return nil, fmt.Errorf("error converting %s from unstructured error: %w", ResourceID(in), err)
 	}


### PR DESCRIPTION
Fixes https://github.com/kyverno/kuttl/issues/24

- If a nonexisting assert, apply, or error file is present in the test step it will fail
- If TestStep contains any random field ( foo ) it will fail
- It would check the yaml indentation on TestStep, assert files, error files, and apply files. ( Strict decoder )