### PR TITLE
Aggregate and display failures at the bottom of output with minor code refactoring.

### DIFF
--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
+	"github.com/pkg/errors"
 
 	"github.com/kyverno/kuttl/pkg/version"
 )
@@ -40,21 +41,20 @@ func (c *Client) GetByteBuffer(url string) (*bytes.Buffer, error) {
 
 	resp, err := c.Get(url)
 	if err != nil {
-		return buf, err
+		return buf, errors.Wrapf(err, "failed to fetch %s", url)
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != 200 {
 		return buf, fmt.Errorf("failed to fetch %s : %s", url, resp.Status)
 	}
 
 	_, err = io.Copy(buf, resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error while copying response body")
 	}
-	err = resp.Body.Close()
-	if err != nil {
-		return nil, fmt.Errorf("error when closing the response body %s", err)
-	}
-	return buf, err
+
+	return buf, nil
 }
 
 // DownloadFile expects a url with a file and will save that file to the path provided preserving the file name.
@@ -69,7 +69,7 @@ func (c *Client) Download(url string, path string) error {
 	// Get the data
 	resp, err := c.Get(url)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to perform HTTP GET")
 	}
 	defer resp.Body.Close()
 
@@ -79,14 +79,14 @@ func (c *Client) Download(url string, path string) error {
 	}
 	// captures errors other than does not exist
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return errors.Wrap(err, "error checking file existence")
 	}
 
 	// Create the file with .tmp extension, so that we won't overwrite a
 	// file until it's downloaded fully
 	out, err := os.Create(path + ".tmp")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error creating temporary file")
 	}
 	defer out.Close()
 
@@ -94,7 +94,7 @@ func (c *Client) Download(url string, path string) error {
 	counter := &writeCounter{Name: filepath.Base(path)}
 	_, err = io.Copy(out, io.TeeReader(resp.Body, counter))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error while copying response body to file")
 	}
 
 	// The progress use the same line so print a new line once it's finished downloading
@@ -103,7 +103,7 @@ func (c *Client) Download(url string, path string) error {
 	// Rename the tmp file back to the original file
 	err = os.Rename(path+".tmp", path)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error renaming temporary file")
 	}
 
 	return nil

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -10,7 +10,7 @@ import (
 	testutils "github.com/kyverno/kuttl/pkg/test/utils"
 )
 
-// IsURL returns true if string is an URL
+// IsURL returns true if string is a URL
 func IsURL(str string) bool {
 	u, err := url.Parse(str)
 	return err == nil && u.Scheme != "" && u.Host != ""

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -612,6 +612,16 @@ func (h *Harness) Stop() {
 
 		h.kind = nil
 	}
+
+	h.T.Logf("Total test failures: %d", h.report.Failures)
+	for _, j := range h.report.Testsuite {
+		h.T.Logf("Test suite %s: %d failures", j.Name, j.Failures)
+		for _, v := range j.Testcase {
+			if v.Failure != nil {
+				h.T.Logf("test %s failed: %s", v.Name, v.Failure.Message)
+			}
+		}
+	}
 }
 
 // wraps Test.Fatal in order to clean up harness

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -489,7 +489,7 @@ func (h *Harness) Run() {
 // Setup spins up the test env based on configuration
 // It can be used to start env which can than be modified prior to running tests, otherwise use Run().
 func (h *Harness) Setup() {
-	rand.Seed(time.Now().UTC().UnixNano())
+	rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 	h.report = report.NewSuiteCollection(h.TestSuite.Name)
 	h.T.Log("starting setup")
 

--- a/pkg/test/kind.go
+++ b/pkg/test/kind.go
@@ -92,6 +92,7 @@ func (k *kind) Stop() error {
 	return k.Provider.Delete(k.context, k.explicitPath)
 }
 
+// loadContainer loads a Docker container image onto a KIND node.
 func loadContainer(docker testutils.DockerClient, node nodes.Node, container string) error {
 	image, err := docker.ImageSave(context.TODO(), []string{container})
 	if err != nil {
@@ -105,7 +106,5 @@ func loadContainer(docker testutils.DockerClient, node nodes.Node, container str
 
 // IsMinVersion checks if pass ver is the min required kind version
 func IsMinVersion(ver string) bool {
-	minVersion := "kind.sigs.k8s.io/v1alpha4"
-	comp := version.CompareKubeAwareVersionStrings(minVersion, ver)
-	return comp != -1
+	return version.CompareKubeAwareVersionStrings("kind.sigs.k8s.io/v1alpha4", ver) != -1
 }

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -563,6 +564,11 @@ func (s *Step) LoadYAML(file string) error {
 	for _, apply := range s.Apply {
 		if apply.object.GetObjectKind().GroupVersionKind().Kind == "TestStep" {
 			if testStep, ok := apply.object.(*harness.TestStep); ok {
+				// validate yaml files and teststep fields for TestStep objects
+				err := testStepYamlValidate(testStep, s.Dir)
+				if err != nil {
+					return fmt.Errorf("failed to validate TestStep object from %s, error: %v", file, err)
+				}
 				if s.Step != nil {
 					return fmt.Errorf("more than 1 TestStep not allowed in step %q", s.Name)
 				}
@@ -690,4 +696,50 @@ func hasTimeoutErr(err []error) bool {
 		}
 	}
 	return false
+}
+
+func testStepYamlValidate(ts *harness.TestStep, dir string) error {
+	// If apply field is not present, then either command or delete needs to be present,
+	// if both are not specified it should throw an error
+	if len(ts.Apply) == 0 && len(ts.Commands) == 0 && len(ts.Error) == 0 {
+		return fmt.Errorf("if apply field is not specified either command or delete is expected")
+	}
+
+	// Assert and Error fields require Apply field
+	if (len(ts.Assert) != 0 || len(ts.Error) != 0) && len(ts.Apply) == 0 {
+		return fmt.Errorf("cannot have assert or error field when missing apply field")
+	}
+
+	// Validation for referenced field files
+	for _, Apply := range ts.Apply {
+		err := validateFieldFile(Apply.File, dir)
+		if err != nil {
+			return errors.Join(err, fmt.Errorf("error in apply field"))
+		}
+	}
+	for _, Assert := range ts.Assert {
+		err := validateFieldFile(Assert, dir)
+		if err != nil {
+			return errors.Join(err, fmt.Errorf("error in assert field"))
+		}
+	}
+	for _, Error := range ts.Error {
+		err := validateFieldFile(Error, dir)
+		if err != nil {
+			return errors.Join(err, fmt.Errorf("error in error field"))
+		}
+	}
+
+	return nil
+}
+
+// validateFieldFile checks if the reference file exists
+func validateFieldFile(file string, dir string) error {
+	completeFile := filepath.Join(dir, file)
+	_, err := os.Stat(completeFile)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("the file %s specified in the field does not exist", completeFile)
+	}
+
+	return nil
 }

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -173,6 +173,7 @@ func (s *Step) DeleteExisting(namespace string) error {
 	})
 }
 
+// doApply performs the actual object creation/update and cleanup.
 func doApply(test *testing.T, skipDelete bool, logger testutils.Logger, timeout int, dClient discovery.DiscoveryInterface, cl client.Client, obj client.Object, namespace string) error {
 	_, _, err := testutils.Namespaced(dClient, obj, namespace)
 	if err != nil {
@@ -265,6 +266,7 @@ func (s *Step) GetTimeout() int {
 	return timeout
 }
 
+// list returns a list of unstructured objects of a given GVK and namespace.
 func list(cl client.Client, gvk schema.GroupVersionKind, namespace string) ([]unstructured.Unstructured, error) {
 	list := unstructured.UnstructuredList{}
 	list.SetGroupVersionKind(gvk)
@@ -680,6 +682,7 @@ func cleanPath(path, dir string) string {
 	return filepath.Join(dir, path)
 }
 
+// hasTimeoutErr checks if the error list contains a context.DeadlineExceeded error.
 func hasTimeoutErr(err []error) bool {
 	for i := range err {
 		if errors.Is(err[i], context.DeadlineExceeded) {

--- a/pkg/test/utils/logger.go
+++ b/pkg/test/utils/logger.go
@@ -54,7 +54,7 @@ func (t *TestLogger) WithPrefix(prefix string) Logger {
 
 // Write implements the io.Writer interface.
 // Logs each line written to it, buffers incomplete lines until the next Write() call.
-func (t *TestLogger) Write(p []byte) (n int, err error) {
+func (t *TestLogger) Write(p []byte) (int, error) {
 	t.buffer = append(t.buffer, p...)
 
 	splitBuf := bytes.Split(t.buffer, []byte{'\n'})

--- a/pkg/test/utils/subset.go
+++ b/pkg/test/utils/subset.go
@@ -69,7 +69,7 @@ func IsSubset(expected, actual interface{}) error {
 			if !actualValue.IsValid() {
 				return &SubsetError{
 					path:    []string{iter.Key().String()},
-					message: "key is missing from map",
+					message: fmt.Sprintf("key '%s' is missing from map", iter.Key().String()),
 				}
 			}
 

--- a/pkg/test/utils/testing.go
+++ b/pkg/test/utils/testing.go
@@ -21,25 +21,19 @@ func RunTests(testName string, testToRun string, parallelism int, testFunc func(
 	testing.Init()
 
 	// Set the verbose test flag to true since we are not using the regular go test CLI.
-	if err := flag.Set("test.v", "true"); err != nil {
-		panic(err)
-	}
+	setFlag("test.v", "true")
 
 	// Set the -run flag on the Go test harness.
 	// See the go test documentation: https://golang.org/pkg/cmd/go/internal/test/
 	if testToRun != "" {
-		if err := flag.Set("test.run", fmt.Sprintf("//%s", testToRun)); err != nil {
-			panic(err)
-		}
+		setFlag("test.run", fmt.Sprintf("//%s", testToRun))
 	}
 
 	parallelismStr := "8"
 	if parallelism != 0 {
 		parallelismStr = fmt.Sprintf("%d", parallelism)
 	}
-	if err := flag.Set("test.parallel", parallelismStr); err != nil {
-		panic(err)
-	}
+	setFlag("test.parallel", parallelismStr)
 
 	os.Exit(testing.MainStart(&testDeps{}, []testing.InternalTest{
 		{
@@ -47,6 +41,14 @@ func RunTests(testName string, testToRun string, parallelism int, testFunc func(
 			F:    testFunc,
 		},
 	}, nil, nil, nil).Run())
+}
+
+// setFlag is a utility function that sets the value of a command-line flag using the flag package.
+// If an error occurs while setting the flag, the function panics with the provided error.
+func setFlag(name, value string) {
+	if err := flag.Set(name, value); err != nil {
+		panic(err)
+	}
 }
 
 // testDeps implements the testDeps interface for MainStart.
@@ -79,7 +81,11 @@ func (testDeps) StopCPUProfile() {
 }
 
 func (testDeps) WriteProfileTo(name string, w io.Writer, debug int) error {
-	return pprof.Lookup(name).WriteTo(w, debug)
+	prof := pprof.Lookup(name)
+	if prof == nil {
+		return fmt.Errorf("profile %q not found", name)
+	}
+	return prof.WriteTo(w, debug)
 }
 
 func (testDeps) ImportPath() string {


### PR DESCRIPTION
This pull request addresses issue #25, while also incorporating code refactoring to enhance error messages and code-reusability. Please provide feedback if the current approach of logging errors is not aligned with the intended behavior or if there are any suggestions for further improvements.