### PR TITLE
[Feature] - Aggregate and display failures at the bottom of output

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -612,6 +612,7 @@ func (h *Harness) Stop() {
 
 		h.kind = nil
 	}
+	h.DisplayFailedTest()
 }
 
 // wraps Test.Fatal in order to clean up harness
@@ -639,6 +640,30 @@ func (h *Harness) Report() {
 	}
 	if err := h.report.Report(h.TestSuite.ArtifactsDir, h.reportName(), report.Type(h.TestSuite.ReportFormat)); err != nil {
 		h.fatal(fmt.Errorf("fatal error writing report: %v", err))
+	}
+}
+
+func (h *Harness) DisplayFailedTest() {
+	h.logTotalFailures()
+	h.logEachTestSuiteFailures()
+}
+
+func (h *Harness) logTotalFailures() {
+	h.logger.Logf("Total test failures: %d", h.report.Failures)
+}
+
+func (h *Harness) logEachTestSuiteFailures() {
+	for _, suite := range h.report.Testsuite {
+		h.logger.Logf("Test suite %s: %d failures", suite.Name, suite.Failures)
+		h.logTestCaseFailures(suite)
+	}
+}
+
+func (h *Harness) logTestCaseFailures(suite *report.Testsuite) {
+	for _, testCase := range suite.Testcase {
+		if testCase.Failure != nil {
+			h.logger.Logf("test %s failed: %s", testCase.Name, testCase.Failure.Message)
+		}
 	}
 }
 


### PR DESCRIPTION
What this PR does / why we need it
When any tests fail in a TestCase containing multiple tests it aggregate and display the failed tests together as the final portion of the output.

Fixes https://github.com/kyverno/kuttl/issues/25
