### PR TITLE
[Feature] : Halt testing upon the first failure

### DIFF
--- a/crds/testsuite-json-schema.yaml
+++ b/crds/testsuite-json-schema.yaml
@@ -43,6 +43,10 @@ properties:
     description: If set, do not delete the mocked control plane or kind cluster.
     type: boolean
     default: false
+  stopOnFirstFailure:
+    description: StopOnFirstFailure determines whether the test should stop upon encountering the first failure.
+    type: boolean
+    default: false   
   timeout:
     description: Override the default timeout of 30 seconds (in seconds).
     type: integer

--- a/crds/testsuite_crd.yaml
+++ b/crds/testsuite_crd.yaml
@@ -59,6 +59,10 @@ spec:
               description: If set, do not delete the mocked control plane or kind cluster.
               type: boolean
               default: false
+            stopOnFirstFailure:
+              description: StopOnFirstFailure determines whether the test should stop upon encountering the first failure.
+              type: boolean
+              default: false
             timeout:
               description: Override the default timeout of 30 seconds (in seconds).
               type: integer

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -51,6 +51,8 @@ type TestSuite struct {
 	SkipDelete bool `json:"skipDelete"`
 	// If set, do not delete the mocked control plane or kind cluster.
 	SkipClusterDelete bool `json:"skipClusterDelete"`
+	// StopOnFirstFailure determines whether the test should stop upon encountering the first failure.
+	StopOnFirstFailure bool `json:"stopOnFirstFailure"`
 	// Override the default timeout of 30 seconds (in seconds).
 	// +kubebuilder:validation:Format:=int64
 	Timeout int `json:"timeout"`

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -52,6 +52,7 @@ func newTestCmd() *cobra.Command { //nolint:gocyclo
 	kindContext := ""
 	skipDelete := false
 	skipClusterDelete := false
+	stopOnFirstFailure := false
 	parallel := 0
 	artifactsDir := ""
 	mockControllerFile := ""
@@ -161,6 +162,10 @@ For more detailed documentation, visit: https://kuttl.dev`,
 				options.SkipClusterDelete = skipClusterDelete
 			}
 
+			if isSet(flags, "exit-first-error") {
+				options.StopOnFirstFailure = stopOnFirstFailure
+			}
+
 			if isSet(flags, "parallel") {
 				options.Parallel = parallel
 			}
@@ -253,6 +258,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 	testCmd.Flags().StringVar(&artifactsDir, "artifacts-dir", "", "Directory to output kind logs to (if not specified, the current working directory).")
 	testCmd.Flags().BoolVar(&skipDelete, "skip-delete", false, "If set, do not delete resources created during tests (helpful for debugging test failures, implies --skip-cluster-delete).")
 	testCmd.Flags().BoolVar(&skipClusterDelete, "skip-cluster-delete", false, "If set, do not delete the mocked control plane or kind cluster.")
+	testCmd.Flags().BoolVar(&stopOnFirstFailure, "stop-on-first-failure", false, "Stop testing upon the first failure encountered")
 	// The default value here is only used for the help message. The default is actually enforced in RunTests.
 	testCmd.Flags().IntVar(&parallel, "parallel", 8, "The maximum number of tests to run at once.")
 	testCmd.Flags().IntVar(&timeout, "timeout", 30, "The timeout to use as default for TestSuite configuration.")

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -162,7 +162,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 				options.SkipClusterDelete = skipClusterDelete
 			}
 
-			if isSet(flags, "exit-first-error") {
+			if isSet(flags, "stop-on-first-failure") {
 				options.StopOnFirstFailure = stopOnFirstFailure
 			}
 

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -435,7 +435,7 @@ func (h *Harness) RunTests() {
 						failureOccurred = true
 					}
 					suite.AddTestcase(tc)
-					// Check after every test case if a failure has occurred and the flag is set
+					// Check after every test case if a failure has occurred
 					if failureOccurred && h.TestSuite.StopOnFirstFailure {
 						t.SkipNow()
 						return


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR would skip all the Further Testing if any of the test failed if user passed the field `stopOnFirstFailure` to be true

It is much needed as it prevents waste of time and processing in order for a user/contributor to know what may be broken and requires remediation.

Fixes https://github.com/kyverno/kuttl/issues/26
